### PR TITLE
Fixed virtualbox/ubuntu12.04

### DIFF
--- a/virtualbox/ubuntu12.04.yaml
+++ b/virtualbox/ubuntu12.04.yaml
@@ -48,7 +48,7 @@ global:
     proxy_cache: 10.0.2.2
 
   in_context:
-    cmd: ssh -o ConnectTimeout=1 -F $$ssh_config_file $$kameleon_recipe_name -t chroot $$rootfs /bin/bash
+    cmd: ssh -o ConnectTimeout=1 -F $$ssh_config_file $$kameleon_recipe_name -t /bin/bash
     workdir: /root/kameleon_workdir
     proxy_cache: 10.0.2.2
 


### PR DESCRIPTION
For virtualbox/ubuntu12.04 recipe, the command used to access context_in is an ssh that execute a chroot. It cause the program to crash (as there is no 'roots' folder to chroot on, on the machine we just ssh'd).
